### PR TITLE
Fix 404 incomplete clan war

### DIFF
--- a/web/dist/www/clanwar.html
+++ b/web/dist/www/clanwar.html
@@ -7,7 +7,7 @@
                         2016-01-02T01:01:01Z
                     </local-time>
                 </a>
-                <a class="lcw" title="Incomplete clanwar" href="/questions/#completed-clanwar"><i class="fa fa-exclamation"></i></a>
+                <a class="lcw" title="Incomplete clanwar" href="https://docs.actionfps.com/glossary.html#clanwar"><i class="fa fa-exclamation"></i></a>
             </h2>
         </header>
 


### PR DESCRIPTION
Fix link on actionfps portal to explain why clanwar is incomplete. Linking to glossary
https://docs.actionfps.com/glossary.html#clanwar